### PR TITLE
Update rainbow_effect.py

### DIFF
--- a/Code/Project_5/rainbow_effect.py
+++ b/Code/Project_5/rainbow_effect.py
@@ -5,9 +5,9 @@
 #based on Tony DiCola's NeoPixel library strandtest example
 
 #import necessary libraries
-from neopixel import *
 from time import sleep
 from gpiozero import Button, MCP3008
+from rpi_ws281x import *
 
 # LED strip configuration
 LED_COUNT = 14 #number of LED pixels


### PR DESCRIPTION
Removing unused library and adding import from the correct library. 
Neopixel library is not used in this code and Adafruit_NeoPixel is part of the rpi_ws281x library.